### PR TITLE
symbolic: add a more specific error if someone tries to do `cos*x` (#…

### DIFF
--- a/apps/prairielearn/python/python_helper_sympy.py
+++ b/apps/prairielearn/python/python_helper_sympy.py
@@ -200,6 +200,12 @@ class HasInvalidVariableError(BaseSympyError):
 
 
 @dataclass
+class FunctionNameUsedWithoutArguments(BaseSympyError):
+    offset: int
+    text: str
+
+
+@dataclass
 class HasParseError(BaseSympyError):
     offset: int
 
@@ -235,23 +241,29 @@ class CheckFunctions(ast.NodeVisitor):
         self.functions = functions
 
     def visit_Call(self, node: ast.Call) -> None:
-        if isinstance(node.func, ast.Name):
-            if node.func.id not in self.functions:
-                err_node = get_parent_with_location(node)
-                raise HasInvalidFunctionError(err_node.col_offset, err_node.func.id)
+        if isinstance(node.func, ast.Name) and node.func.id not in self.functions:
+            err_node = get_parent_with_location(node)
+            raise HasInvalidFunctionError(err_node.col_offset, err_node.func.id)
         self.generic_visit(node)
 
 
 class CheckVariables(ast.NodeVisitor):
-    def __init__(self, variables: SympyMapT) -> None:
+    def __init__(self, variables: SympyMapT, functions: SympyMapT) -> None:
+        # functions is only used for error type, if someone writes "exp + 2"
         self.variables = variables
+        self.functions = functions
 
     def visit_Name(self, node: ast.Name) -> None:
-        if isinstance(node.ctx, ast.Load):
-            if not is_name_of_function(node):
-                if node.id not in self.variables:
-                    err_node = get_parent_with_location(node)
-                    raise HasInvalidVariableError(err_node.col_offset, err_node.id)
+        if (
+            isinstance(node.ctx, ast.Load)
+            and not is_name_of_function(node)
+            and node.id not in self.variables
+        ):
+            err_node = get_parent_with_location(node)
+            if node.id in self.functions:
+                raise FunctionNameUsedWithoutArguments(err_node.col_offset, err_node.id)
+            else:
+                raise HasInvalidVariableError(err_node.col_offset, err_node.id)
         self.generic_visit(node)
 
 
@@ -297,7 +309,9 @@ def ast_check(expr: str, locals_for_eval: LocalsForEval) -> None:
     CheckFunctions(locals_for_eval["functions"]).visit(root)
 
     # Disallow variables that are not in locals_for_eval
-    CheckVariables(locals_for_eval["variables"]).visit(root)
+    CheckVariables(locals_for_eval["variables"], locals_for_eval["functions"]).visit(
+        root
+    )
 
     # Disallow AST nodes that are not in whitelist
     #
@@ -654,6 +668,13 @@ def validate_string_as_sympy(
     except HasInvalidVariableError as err:
         return (
             f'Your answer refers to an invalid variable "{err.text}". '
+            f"<br><br><pre>{point_to_error(expr, err.offset)}</pre>"
+            "Note that the location of the syntax error is approximate."
+        )
+    except FunctionNameUsedWithoutArguments as err:
+        return (
+            f'Your answer mentions the function "{err.text}" without '
+            "applying it to anything. "
             f"<br><br><pre>{point_to_error(expr, err.offset)}</pre>"
             "Note that the location of the syntax error is approximate."
         )

--- a/apps/prairielearn/python/python_helper_sympy_test.py
+++ b/apps/prairielearn/python/python_helper_sympy_test.py
@@ -278,7 +278,8 @@ class TestExceptions:
     NO_FLOATS_CASES = ["3.5", "4.2n", "3.5*n", "3.14159*n**2", "sin(2.3)"]
     INVALID_EXPRESSION_CASES = ["5==5", "5!=5", "5>5", "5<5", "5>=5", "5<=5"]
     INVALID_FUNCTION_CASES = ["eval(n)", "f(n)", "g(n)+cos(n)", "dir(n)", "sin(f(n))"]
-    INVALID_VARIABLE_CASES = ["x", "y", "z*n"]
+    INVALID_VARIABLE_CASES = ["x", "exp(y)", "z*n"]
+    FUNCTION_NOT_CALLED_CASES = ["2+exp", "cos*n"]
     INVALID_PARSE_CASES = ["(", "n**", "n**2+", "!"]
     INVALID_ESCAPE_CASES = ["\\", "n + 2 \\", "2 \\"]
     INVALID_COMMENT_CASES = ["#", "n + 2 # comment", "# x"]
@@ -316,7 +317,12 @@ class TestExceptions:
 
     @pytest.mark.parametrize("a_sub", INVALID_VARIABLE_CASES)
     def test_invalid_variable(self, a_sub: str) -> None:
-        with pytest.raises(phs.HasInvalidSymbolError):
+        with pytest.raises((phs.HasInvalidSymbolError, phs.HasInvalidVariableError)):
+            phs.convert_string_to_sympy(a_sub, self.VARIABLES)
+
+    @pytest.mark.parametrize("a_sub", FUNCTION_NOT_CALLED_CASES)
+    def test_function_not_called(self, a_sub: str) -> None:
+        with pytest.raises(phs.FunctionNameUsedWithoutArguments):
             phs.convert_string_to_sympy(a_sub, self.VARIABLES)
 
     @pytest.mark.parametrize("a_sub", INVALID_PARSE_CASES)


### PR DESCRIPTION
…9323)

* add a more specific error message for '1 / exp'

* better name for the error message, fix dumb copy-paste mistake

* appease linter

* nested ifs => and